### PR TITLE
feat: add initial CI/automation/Go mod init + GetModule

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    name: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Lint
+        run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: CI
+on: [push]
+jobs:
+
+  build:
+    name: Build and Test
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-10.15, ubuntu-20.04, windows-2019]
+        go: ["1.16", "1.17"]
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go }}
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go }}
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Build
+      run: make build
+
+    - name: Test
+      run: make test
+
+    - name: Benchmarks
+      run: make bench

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,11 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
 
+    - name: Vet Code
+      run: make vet
+
     - name: Build
       run: make build
 
     - name: Test
       run: make test
-
-    - name: Benchmarks
-      run: make bench

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+#
+cmd/benchcheck/benchcheck

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ lint:
 test:
 	go test -timeout 10s -race -coverprofile=$(cov) ./...
 
+.PHONY: vet
+vet:
+	go vet ./...
+
 .PHONY: coverage
 coverage: test
 	go tool cover -html=$(cov) -o=$(covhtml)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+version?=$(shell git rev-list -1 HEAD)
+cov=coverage.out
+covhtml=coverage.html
+buildflags=-ldflags "-X main.Version=${version}"
+golangci_lint_version=1.41.1
+name=benchcheck
+
+all: lint test build
+
+.PHONY: build
+build:
+	go build $(buildflags) -o ./cmd/$(name)/$(name) ./cmd/$(name)
+
+.PHONY: lint
+lint:
+	docker run --rm -v `pwd`:/app -w /app golangci/golangci-lint:v$(golangci_lint_version)  golangci-lint run ./...
+
+.PHONY: test
+test:
+	go test -timeout 10s -race -coverprofile=$(cov) ./...
+
+.PHONY: coverage
+coverage: test
+	go tool cover -html=$(cov) -o=$(covhtml)
+
+.PHONY: install
+install:
+	go install $(buildflags) ./cmd/$(name)
+
+.PHONY: cleanup
+cleanup:
+	rm -f cmd/$(name)/$(name)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint:
 
 .PHONY: test
 test:
-	go test -timeout 10s -race -coverprofile=$(cov) ./...
+	go test -timeout 60s -race -coverprofile=$(cov) ./...
 
 .PHONY: vet
 vet:

--- a/benchcheck.go
+++ b/benchcheck.go
@@ -1,0 +1,4 @@
+package benchcheck
+
+func GetModule() {
+}

--- a/benchcheck.go
+++ b/benchcheck.go
@@ -22,6 +22,10 @@ func GetModule(name string, version string) (string, error) {
 		Error string // error loading module
 		Dir   string // absolute path to cached source root directory
 	}{}
-	json.Unmarshal(output, &parsedResult)
+
+	err := json.Unmarshal(output, &parsedResult)
+	if err != nil {
+		return "", fmt.Errorf("error parsing %q : %v", string(output), err)
+	}
 	return parsedResult.Dir, nil
 }

--- a/benchcheck.go
+++ b/benchcheck.go
@@ -1,4 +1,11 @@
 package benchcheck
 
-func GetModule() {
+// GetModule will download a specific version of a module and
+// return a directory where you can find the module code.
+// It leverages "go get" to do the job, so the returned directory
+// should be considered read only (it is part of the Go cache).
+//
+// A non-nil error is returned if it fails.
+func GetModule(name string, version string) (string, error) {
+	return "", nil
 }

--- a/benchcheck.go
+++ b/benchcheck.go
@@ -15,15 +15,17 @@ import (
 func GetModule(name string, version string) (string, error) {
 	// Reference: https://golang.org/ref/mod#go-mod-download
 	cmd := exec.Command("go", "mod", "download", "-json", fmt.Sprintf("%s@%s", name, version))
-	output, _ := cmd.CombinedOutput()
-	// TODO: handle errors
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return "", fmt.Errorf("error fetching module: %v : output: %v", err, output)
+	}
 
 	parsedResult := struct {
-		Error string // error loading module
-		Dir   string // absolute path to cached source root directory
+		Dir string // absolute path to cached source root directory
 	}{}
 
-	err := json.Unmarshal(output, &parsedResult)
+	err = json.Unmarshal(output, &parsedResult)
 	if err != nil {
 		return "", fmt.Errorf("error parsing %q : %v", string(output), err)
 	}

--- a/benchcheck.go
+++ b/benchcheck.go
@@ -1,5 +1,11 @@
 package benchcheck
 
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
 // GetModule will download a specific version of a module and
 // return a directory where you can find the module code.
 // It leverages "go get" to do the job, so the returned directory
@@ -7,5 +13,15 @@ package benchcheck
 //
 // A non-nil error is returned if it fails.
 func GetModule(name string, version string) (string, error) {
-	return "", nil
+	// Reference: https://golang.org/ref/mod#go-mod-download
+	cmd := exec.Command("go", "mod", "download", "-json", fmt.Sprintf("%s@%s", name, version))
+	output, _ := cmd.CombinedOutput()
+	// TODO: handle errors
+
+	parsedResult := struct {
+		Error string // error loading module
+		Dir   string // absolute path to cached source root directory
+	}{}
+	json.Unmarshal(output, &parsedResult)
+	return parsedResult.Dir, nil
 }

--- a/benchcheck_test.go
+++ b/benchcheck_test.go
@@ -1,0 +1,55 @@
+package benchcheck_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/madlambda/benchcheck"
+)
+
+func TestGetModule(t *testing.T) {
+	tests := []struct {
+		desc          string
+		moduleName    string
+		moduleVersion string
+		wantErr       bool
+	}{
+		{
+			desc:          "ValidVersion",
+			moduleName:    "github.com/madlambda/jtoh",
+			moduleVersion: "v0.1.0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			modDir, err := benchcheck.GetModule(test.moduleName, test.moduleVersion)
+
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf(
+					"benchcheck.GetModule(%q, %q): unexpected error : %v",
+					test.moduleName,
+					test.moduleVersion,
+					err,
+				)
+			}
+
+			fileinfo, err := os.Stat(modDir)
+
+			if err != nil {
+				t.Fatalf("os.Stat(%q): unexpected error : %v", modDir, err)
+			}
+
+			if !fileinfo.IsDir() {
+				t.Fatalf("want %q to be a dir, details : %v", modDir, fileinfo)
+			}
+		})
+	}
+}

--- a/benchcheck_test.go
+++ b/benchcheck_test.go
@@ -25,6 +25,11 @@ func TestGetModule(t *testing.T) {
 			moduleVersion: "latest",
 		},
 		{
+			desc:          "UsingCommitSha",
+			moduleName:    "github.com/madlambda/jtoh",
+			moduleVersion: "5cd825858d7dcc41c3b453ed10ecf0983b139243",
+		},
+		{
 			desc:          "InvalidVersion",
 			moduleName:    "github.com/madlambda/jtoh",
 			moduleVersion: "StoNkS",

--- a/benchcheck_test.go
+++ b/benchcheck_test.go
@@ -19,6 +19,23 @@ func TestGetModule(t *testing.T) {
 			moduleName:    "github.com/madlambda/jtoh",
 			moduleVersion: "v0.1.0",
 		},
+		{
+			desc:          "UsingLatest",
+			moduleName:    "github.com/madlambda/jtoh",
+			moduleVersion: "latest",
+		},
+		{
+			desc:          "InvalidVersion",
+			moduleName:    "github.com/madlambda/jtoh",
+			moduleVersion: "StoNkS",
+			wantErr:       true,
+		},
+		{
+			desc:          "InvalidModule",
+			moduleName:    "git.duh/suchwrong/muchfail",
+			moduleVersion: "latest",
+			wantErr:       true,
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/benchcheck/benchcheck.go
+++ b/cmd/benchcheck/benchcheck.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("TODO")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/madlambda/benchcheck
+
+go 1.17


### PR DESCRIPTION
Focusing on basic bootstrap of the project + retrieving different versions of a module + providing dir that can be used to run benchmarks. Given that we should be able to run benchmarks inside the dir (even for specific commits), and then compare results between them.