### PR TITLE
test: improve detail on errors

### DIFF
--- a/benchcheck_test.go
+++ b/benchcheck_test.go
@@ -151,7 +151,7 @@ func TestBenchModuleNoBenchmarks(t *testing.T) {
 	t.Parallel()
 
 	const (
-		module     = "github.com/madlambda/benchchec"
+		module     = "github.com/madlambda/benchcheck"
 		modversion = "f15923bf230cc7331ad869fcdaac35172f8b7f38"
 	)
 	mod, err := benchcheck.GetModule(module, modversion)

--- a/benchcheck_test.go
+++ b/benchcheck_test.go
@@ -173,7 +173,7 @@ func assertNoError(t *testing.T, err error, details ...interface{}) {
 	msg := ""
 
 	if len(details) > 0 {
-		msg = fmt.Sprintf(details[0].(string), details[1:]...) + ":"
+		msg = fmt.Sprintf(details[0].(string), details[1:]...) + ": "
 	}
 
 	msg += err.Error()

--- a/benchcheck_test.go
+++ b/benchcheck_test.go
@@ -1,6 +1,8 @@
 package benchcheck_test
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -131,10 +133,10 @@ func TestBenchModule(t *testing.T) {
 		modversion = "73348d58a038746fd4f92dd1e77344a58a4f8505"
 	)
 	mod, err := benchcheck.GetModule(module, modversion)
-	assert.NoError(t, err, "benchcheck.GetModule(%q, %q)", module, modversion)
+	assertNoError(t, err, "benchcheck.GetModule(%q, %q)", module, modversion)
 
 	res, err := benchcheck.RunBench(mod)
-	assert.NoError(t, err, "benchcheck.RunBench(%v)", mod)
+	assertNoError(t, err, "benchcheck.RunBench(%v)", mod)
 
 	assert.EqualInts(t, 1, len(res), "want single result, got: %v", res)
 	if !strings.HasPrefix(res[0], "BenchmarkFake") {
@@ -149,14 +151,37 @@ func TestBenchModuleNoBenchmarks(t *testing.T) {
 	t.Parallel()
 
 	const (
-		module     = "github.com/madlambda/benchcheck"
+		module     = "github.com/madlambda/benchchec"
 		modversion = "f15923bf230cc7331ad869fcdaac35172f8b7f38"
 	)
 	mod, err := benchcheck.GetModule(module, modversion)
-	assert.NoError(t, err, "benchcheck.GetModule(%q, %q)", module, modversion)
+	assertNoError(t, err, "benchcheck.GetModule(%q, %q)", module, modversion)
 
 	res, err := benchcheck.RunBench(mod)
-	assert.NoError(t, err, "benchcheck.RunBench(%v)", mod)
+	assertNoError(t, err, "benchcheck.RunBench(%v)", mod)
 
 	assert.EqualInts(t, 0, len(res), "want no results, got: %v", res)
+}
+
+func assertNoError(t *testing.T, err error, details ...interface{}) {
+	t.Helper()
+
+	if err == nil {
+		return
+	}
+
+	msg := ""
+
+	if len(details) > 0 {
+		msg = fmt.Sprintf(details[0].(string), details[1:]...) + ":"
+	}
+
+	msg += err.Error()
+
+	var cmderr *benchcheck.CmdError
+	if errors.As(err, &cmderr) {
+		msg += "\ncmd stdout + stderr:\n" + cmderr.Output
+	}
+
+	t.Fatal(msg)
 }


### PR DESCRIPTION
So we can get full details on cmd related errors on tests, but not imposing huge error messages by default on the error instances.