### PR TITLE
feat: first working cmd line

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,5 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v1
+        with:
+          go-version: "1.18"
+
       - name: Lint
         run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-11, ubuntu-20.04, windows-2019, windows-2022]
+        os: [macos-12, macos-11, ubuntu-20.04, windows-2019, windows-2022]
         go: ["1.16", "1.17", "1.18"]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-12, macos-11, ubuntu-20.04, windows-2019, windows-2022]
-        go: ["1.16", "1.17", "1.18"]
+        go: ["1.16", "1.17", "1.18", "1.19"]
 
     steps:
 
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.16", "1.17", "1.18"]
+        go: ["1.16", "1.17", "1.18", "1.19"]
 
     steps:
 

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 version?=$(shell git rev-list -1 HEAD)
 cov=coverage.out
 covhtml=coverage.html
+buildflags=-ldflags "-X main.Version=${version}"
 golangci_lint_version=v1.49.0
+coverage_report ?= coverage.txt
 
-COVERAGE_REPORT ?= coverage.txt
 
 all: lint test build
 
 .PHONY: build
 build:
-	go build -o ./cmd/benchcheck/benchcheck ./cmd/benchcheck
+	go build $(buildflags) -o ./cmd/benchcheck/benchcheck ./cmd/benchcheck
 
 .PHONY: lint
 lint:
@@ -25,15 +26,15 @@ test/integration:
 
 .PHONY: coverage
 coverage: 
-	go test -race -covermode=atomic -coverprofile=$(COVERAGE_REPORT) -tags integration ./...
+	go test -race -covermode=atomic -coverprofile=$(coverage_report) -tags integration ./...
 
 .PHONY: coverage/show
 coverage/show: coverage
-	go tool cover -html=$(COVERAGE_REPORT)
+	go tool cover -html=$(coverage_report)
 
 .PHONY: install
 install:
-	go install ./cmd/benchcheck
+	go install $(buildflags) ./cmd/benchcheck
 
 .PHONY: cleanup
 cleanup:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 version?=$(shell git rev-list -1 HEAD)
 cov=coverage.out
 covhtml=coverage.html
-buildflags=-ldflags "-X main.Version=${version}"
-golangci_lint_version=v1.45.0
-name=benchcheck
+golangci_lint_version=v1.49.0
 
 COVERAGE_REPORT ?= coverage.txt
 
@@ -11,7 +9,7 @@ all: lint test build
 
 .PHONY: build
 build:
-	go build $(buildflags) -o ./cmd/$(name)/$(name) ./cmd/$(name)
+	go build -o ./cmd/benchcheck/benchcheck ./cmd/benchcheck
 
 .PHONY: lint
 lint:
@@ -35,8 +33,8 @@ coverage/show: coverage
 
 .PHONY: install
 install:
-	go install $(buildflags) ./cmd/$(name)
+	go install ./cmd/benchcheck
 
 .PHONY: cleanup
 cleanup:
-	rm -f cmd/$(name)/$(name)
+	rm -f cmd/benchcheck/benchcheck

--- a/benchcheck.go
+++ b/benchcheck.go
@@ -79,7 +79,19 @@ func (c Checker) String() string {
 // Do performs the check on the given StatResult. Returns true
 // if it passed the check, false otherwise.
 func (c Checker) Do(stat StatResult) bool {
-	return false
+	if c.metric != stat.Metric {
+		return true
+	}
+
+	for _, bench := range stat.BenchDiffs {
+		if c.threshold >= 0.0 && bench.Delta > c.threshold {
+			return false
+		}
+		if c.threshold < 0.0 && bench.Delta < c.threshold {
+			return false
+		}
+	}
+	return true
 }
 
 // Path is the absolute path of the module on the filesystem.

--- a/benchcheck.go
+++ b/benchcheck.go
@@ -43,8 +43,8 @@ type BenchDiff struct {
 	Delta float64
 }
 
-// Check represents a check to be performed on a StatResult
-type Check struct {
+// Checker performs checks on StatResult.
+type Checker struct {
 }
 
 // CmdError represents an error running a specific command.
@@ -64,8 +64,15 @@ func (c *CmdError) Error() string {
 	)
 }
 
-func (c Check) String() string {
+// String returns the string representation of the checker.
+func (c Checker) String() string {
 	return "TODO"
+}
+
+// Do performs the check on the given StatResult. Returns true
+// if it passed the check, false otherwise.
+func (c Checker) Do(stat StatResult) bool {
+	return false
 }
 
 // Path is the absolute path of the module on the filesystem.
@@ -200,9 +207,9 @@ func StatModule(name string, oldversion, newversion string) ([]StatResult, error
 	return Stat(oldresults, newresults)
 }
 
-// ParseCheck will parse the given string into a Check.
-func ParseCheck(val string) (Check, error) {
-	return Check{}, nil
+// ParseChecker will parse the given string into a Check.
+func ParseChecker(val string) (Checker, error) {
+	return Checker{}, nil
 }
 
 func newStatResults(tables []*benchstat.Table) []StatResult {

--- a/benchcheck.go
+++ b/benchcheck.go
@@ -43,6 +43,10 @@ type BenchDiff struct {
 	Delta float64
 }
 
+// Check represents a check to be performed on a StatResult
+type Check struct {
+}
+
 // CmdError represents an error running a specific command.
 type CmdError struct {
 	Cmd    *exec.Cmd
@@ -58,6 +62,10 @@ func (c *CmdError) Error() string {
 		c.Cmd.Dir,
 		c.Err,
 	)
+}
+
+func (c Check) String() string {
+	return "TODO"
 }
 
 // Path is the absolute path of the module on the filesystem.
@@ -94,7 +102,7 @@ func (b *BenchResults) Add(res string) {
 // The returned path is an absolute path.
 //
 // Any errors running "go" can be inspected in detail by
-// checking if the returned error is a CmdError.
+// checking if the returned error is a *CmdError.
 func GetModule(name string, version string) (Module, error) {
 	// Reference: https://golang.org/ref/mod#go-mod-download
 	cmd := exec.Command("go", "mod", "download", "-json", fmt.Sprintf("%s@%s", name, version))
@@ -125,7 +133,7 @@ func GetModule(name string, version string) (Module, error) {
 // This function relies on running the "go" command to run benchmarks.
 //
 // Any errors running "go" can be inspected in detail by
-// checking if the returned is a CmdError.
+// checking if the returned is a *CmdError.
 func RunBench(mod Module) (BenchResults, error) {
 	cmd := exec.Command("go", "test", "-bench=.", "./...")
 	cmd.Dir = mod.Path()
@@ -146,10 +154,7 @@ func RunBench(mod Module) (BenchResults, error) {
 	return results, nil
 }
 
-// Stat compares two benchmark results providing a set of results.
-// oldres and newres must be multiple strings where each line is a
-// benchmark result following Go's benchmark output format.
-// Line eg: "BenchmarkName  	 50	  31735022 ns/op	  61.15 MB/s"
+// Stat compares two benchmark results providing a set of stats results.
 func Stat(oldres BenchResults, newres BenchResults) ([]StatResult, error) {
 	// We are using benchstat defaults:
 	//	- https://cs.opensource.google/go/x/perf/+/master:cmd/benchstat/main.go;l=117
@@ -193,6 +198,11 @@ func StatModule(name string, oldversion, newversion string) ([]StatResult, error
 	}
 
 	return Stat(oldresults, newresults)
+}
+
+// ParseCheck will parse the given string into a Check.
+func ParseCheck(val string) (Check, error) {
+	return Check{}, nil
 }
 
 func newStatResults(tables []*benchstat.Table) []StatResult {

--- a/benchcheck_test.go
+++ b/benchcheck_test.go
@@ -130,7 +130,6 @@ func TestGetModule(t *testing.T) {
 
 func TestChecker(t *testing.T) {
 	t.Parallel()
-	t.Skip("TODO")
 
 	type testcase struct {
 		name     string
@@ -184,17 +183,26 @@ func TestChecker(t *testing.T) {
 			want: true,
 		},
 		{
-			name:  "stat check pass on positive if epsilon < 0.1",
+			name:  "stat check fails on positive",
 			check: "metric=+20%",
 			stat: benchcheck.StatResult{
 				Metric:     "metric",
-				BenchDiffs: []benchcheck.BenchDiff{{Delta: 20.09}},
+				BenchDiffs: []benchcheck.BenchDiff{{Delta: 20.1}},
 			},
-			want: true,
+			want: false,
 		},
 		{
-			name:  "stat check fails on positive if epsilon >= 0.1",
-			check: "metric=+20%",
+			name:  "stat check fails on positive with no sign",
+			check: "metric=20%",
+			stat: benchcheck.StatResult{
+				Metric:     "metric",
+				BenchDiffs: []benchcheck.BenchDiff{{Delta: 20.1}},
+			},
+			want: false,
+		},
+		{
+			name:  "stat check fails on positive with no sign and no percent",
+			check: "metric=20",
 			stat: benchcheck.StatResult{
 				Metric:     "metric",
 				BenchDiffs: []benchcheck.BenchDiff{{Delta: 20.1}},
@@ -233,17 +241,17 @@ func TestChecker(t *testing.T) {
 			want: true,
 		},
 		{
-			name:  "stat check pass on negative if epsilon < 0.1",
+			name:  "stat check fails on negative",
 			check: "metric=-20%",
 			stat: benchcheck.StatResult{
 				Metric:     "metric",
-				BenchDiffs: []benchcheck.BenchDiff{{Delta: -20.09}},
+				BenchDiffs: []benchcheck.BenchDiff{{Delta: -20.1}},
 			},
-			want: true,
+			want: false,
 		},
 		{
-			name:  "stat check fails on negative if epsilon >= 0.1",
-			check: "metric=-20%",
+			name:  "stat check fails on negative no percent",
+			check: "metric=-20",
 			stat: benchcheck.StatResult{
 				Metric:     "metric",
 				BenchDiffs: []benchcheck.BenchDiff{{Delta: -20.1}},

--- a/benchcheck_test.go
+++ b/benchcheck_test.go
@@ -165,6 +165,15 @@ func TestChecker(t *testing.T) {
 			want: true,
 		},
 		{
+			name:  "stat check pass on zero",
+			check: "metric=0%",
+			stat: benchcheck.StatResult{
+				Metric:     "metric",
+				BenchDiffs: []benchcheck.BenchDiff{{Delta: 0.0}},
+			},
+			want: true,
+		},
+		{
 			name:  "stat check pass on positive",
 			check: "metric=+20%",
 			stat: benchcheck.StatResult{
@@ -273,8 +282,11 @@ func TestChecker(t *testing.T) {
 		},
 	}
 
-	for _, tcase := range tcases {
+	for _, tc := range tcases {
+		tcase := tc
 		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
 			check, err := benchcheck.ParseChecker(tcase.check)
 			if tcase.parseErr {
 				assert.Error(t, err)

--- a/benchcheck_test.go
+++ b/benchcheck_test.go
@@ -278,9 +278,10 @@ func TestChecker(t *testing.T) {
 			check, err := benchcheck.ParseChecker(tcase.check)
 			if tcase.parseErr {
 				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
+				return
 			}
+
+			assert.NoError(t, err)
 			got := check.Do(tcase.stat)
 			if got != tcase.want {
 				t.Fatalf("check.Do(%s)=%t; want %t", tcase.stat, got, tcase.want)

--- a/cmd/benchcheck/benchcheck.go
+++ b/cmd/benchcheck/benchcheck.go
@@ -9,7 +9,7 @@ import (
 	"github.com/madlambda/benchcheck"
 )
 
-type checkList []benchcheck.Check
+type checkList []benchcheck.Checker
 
 func (c *checkList) String() string {
 	if c == nil {
@@ -23,8 +23,7 @@ func (c *checkList) String() string {
 }
 
 func (c *checkList) Set(val string) error {
-	// TODO: check the val here
-	check, err := benchcheck.ParseCheck(val)
+	check, err := benchcheck.ParseChecker(val)
 	if err != nil {
 		return err
 	}
@@ -39,7 +38,7 @@ func main() {
 	newRev := flag.String("new", "", "the new revision to compare")
 
 	checks := checkList{}
-	flag.Var(&checks, "check", "check to be performed on fmt <metric>=(+|-)<number>%. Eg: time/op=10%")
+	flag.Var(&checks, "check", "check to be performed, defined in the form: <metric>=(+|-)<number>%. Eg: time/op=10%")
 
 	flag.Parse()
 

--- a/cmd/benchcheck/benchcheck.go
+++ b/cmd/benchcheck/benchcheck.go
@@ -1,7 +1,87 @@
 package main
 
-import "fmt"
+import (
+	"flag"
+	"fmt"
+	"log"
+	"runtime/debug"
+	"strings"
+
+	"github.com/madlambda/benchcheck"
+)
+
+type checkList []benchcheck.Check
+
+func (c *checkList) String() string {
+	if c == nil {
+		return ""
+	}
+	strs := make([]string, len(*c))
+	for _, check := range *c {
+		strs = append(strs, check.String())
+	}
+	return strings.Join(strs, ",")
+}
+
+func (c *checkList) Set(val string) error {
+	// TODO: check the val here
+	check, err := benchcheck.ParseCheck(val)
+	if err != nil {
+		return err
+	}
+	*c = append(*c, check)
+	return nil
+}
 
 func main() {
-	fmt.Println("TODO")
+	version := flag.Bool("version", false, "show version")
+	mod := flag.String("mod", "", "module to be bench checked")
+	oldRev := flag.String("old", "", "the old revision to compare")
+	newRev := flag.String("new", "", "the new revision to compare")
+
+	checks := checkList{}
+	flag.Var(&checks, "check", "check to be performed on fmt <metric>=(+|-)<number>%. Eg: time/op=10%")
+
+	flag.Parse()
+
+	if *version {
+		showVersion()
+		return
+	}
+
+	if *mod == "" {
+		log.Fatal("-mod is obligatory")
+	}
+	if *oldRev == "" {
+		log.Fatal("-old is obligatory")
+	}
+	if *newRev == "" {
+		log.Fatal("-new is obligatory")
+	}
+
+	results, err := benchcheck.StatModule(*mod, *oldRev, *newRev)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, result := range results {
+		fmt.Printf("metric: %s\n", result.Metric)
+		for _, diff := range result.BenchDiffs {
+			fmt.Println(diff)
+		}
+	}
+}
+
+func showVersion() {
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				fmt.Printf("go version: %s\n", info.GoVersion)
+				fmt.Printf("benchcheck version: %s\n", setting.Value)
+				return
+			}
+		}
+	}
+	fmt.Println("version: no version info")
 }

--- a/cmd/benchcheck/benchcheck.go
+++ b/cmd/benchcheck/benchcheck.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"runtime/debug"
 	"strings"
 
 	"github.com/madlambda/benchcheck"
@@ -70,18 +69,4 @@ func main() {
 			fmt.Println(diff)
 		}
 	}
-}
-
-func showVersion() {
-	info, ok := debug.ReadBuildInfo()
-	if ok {
-		for _, setting := range info.Settings {
-			if setting.Key == "vcs.revision" {
-				fmt.Printf("go version: %s\n", info.GoVersion)
-				fmt.Printf("benchcheck version: %s\n", setting.Value)
-				return
-			}
-		}
-	}
-	fmt.Println("version: no version info")
 }

--- a/cmd/benchcheck/benchcheck.go
+++ b/cmd/benchcheck/benchcheck.go
@@ -38,7 +38,9 @@ func main() {
 	newRev := flag.String("new", "", "the new revision to compare")
 
 	checks := checkList{}
-	flag.Var(&checks, "check", "check to be performed, defined in the form: <metric>=(+|-)<number>%. Eg: time/op=10%")
+	flag.Var(&checks, "check", fmt.Sprintf(
+		"check to be performed, defined in the form: %s. Eg: time/op=10%%",
+		benchcheck.CheckerFmt))
 
 	flag.Parse()
 

--- a/cmd/benchcheck/version.go
+++ b/cmd/benchcheck/version.go
@@ -1,0 +1,22 @@
+//go:build 1.18
+
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+func showVersion() {
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				fmt.Printf("go version: %s\n", info.GoVersion)
+				fmt.Printf("benchcheck version: %s\n", setting.Value)
+				return
+			}
+		}
+	}
+	fmt.Println("version: no version info")
+}

--- a/cmd/benchcheck/version.go
+++ b/cmd/benchcheck/version.go
@@ -1,4 +1,5 @@
 //go:build 1.18
+// +build 1.18
 
 package main
 

--- a/cmd/benchcheck/version_compat.go
+++ b/cmd/benchcheck/version_compat.go
@@ -1,4 +1,5 @@
 //go:build !go.1.18
+// +build !go.1.18
 
 package main
 

--- a/cmd/benchcheck/version_compat.go
+++ b/cmd/benchcheck/version_compat.go
@@ -1,0 +1,21 @@
+//go:build !go.1.18
+
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+// Version defined via link flags, for compabitily with Go < 1.18
+var Version string
+
+func showVersion() {
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		fmt.Printf("go version: %s\n", info.GoVersion)
+	}
+	if Version != "" {
+		fmt.Printf("benchcheck version: %s\n", Version)
+	}
+}

--- a/cmd/benchcheck/version_compat.go
+++ b/cmd/benchcheck/version_compat.go
@@ -5,18 +5,15 @@ package main
 
 import (
 	"fmt"
-	"runtime/debug"
 )
 
 // Version defined via link flags, for compabitily with Go < 1.18
 var Version string
 
 func showVersion() {
-	info, ok := debug.ReadBuildInfo()
-	if ok {
-		fmt.Printf("go version: %s\n", info.GoVersion)
-	}
 	if Version != "" {
 		fmt.Printf("benchcheck version: %s\n", Version)
+	} else {
+		fmt.Println("benchcheck version: no version info")
 	}
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 0%
+        threshold: null
+    patch:
+      default:
+        target: 0%
+        threshold: null

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/madlambda/benchcheck
 
-go 1.18
+go 1.16
 
 require (
 	github.com/google/go-cmp v0.5.7

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/madlambda/benchcheck
 
-go 1.17
+go 1.18
 
 require (
-	github.com/google/go-cmp v0.5.7 // indirect
-	github.com/madlambda/spells v0.3.0 // indirect
-	golang.org/x/perf v0.0.0-20220411212318-84e58bfe0a7e // indirect
+	github.com/google/go-cmp v0.5.7
+	github.com/madlambda/spells v0.3.0
+	golang.org/x/perf v0.0.0-20220411212318-84e58bfe0a7e
 )

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190927191325-030b2cf1153e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=


### PR DESCRIPTION
To test using benchcheck itself, this check will usually (benchmarks have some noise) pass:

```
benchcheck -mod github.com/madlambda/benchcheck -old 0f9165271a00b54163d3fc4c73d52a13c3747a75 -new e90da7b50cf0e191004809e415c64319465286d7 -check "time/op=-90%"
```

This one will fail:

```
benchcheck -mod github.com/madlambda/benchcheck -old 0f9165271a00b54163d3fc4c73d52a13c3747a75 -new e90da7b50cf0e191004809e415c64319465286d7 -check "time/op=-70%"
```

The check is negative because I made the bench faster, but you can play around inverting the commit ids. I imagine that usual checks will always be positive since you wan't to detect code getting slower or using more memory, but a bench that produces a metric like mb/s (throughput) will se a drop as something bad (less throughput). Multiple checks should also work:

```
benchcheck -mod github.com/madlambda/benchcheck -old 0f9165271a00b54163d3fc4c73d52a13c3747a75 -new e90da7b50cf0e191004809e415c64319465286d7 -check "time/op=-81%" -check "time/op=-90%" -check "whatever=0%" -check "time/op=-50%"
```

It runs all checks, ignores unknow metric on checks and fails if any check fails. It is still quite baroque on the outputs/details, but good enough to start using hopefully :-)

When called with no checks it will just show the benchstat results comparing the two versions (not exactly as benchstat, but the important information IMO, but let me know if I missed something).